### PR TITLE
Fix markdown headers in readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Makes pasting into hyperterm safe and easy
 hpm install hyperterm-paste
 ```
 
-###Description
+### Description
 Now pasting from browser into terminal will never run shell command by itself!
 
 Transformations applied to input:
@@ -16,5 +16,6 @@ Transformations applied to input:
  - multiline input will be concatenated to one line by adding `&&`
  - trailing newline will be removed which prevents from execution
  
-###Escape hatch
+### Escape hatch
 You can still make "raw" paste by using `ctrl` + `shift` + `v`
+


### PR DESCRIPTION
# What?
Adds a space character before the two broken headers

# Why? 
So that headers are rendered correctly

ps. thanks for the awesome plugin ;)  
